### PR TITLE
Update Node.js versions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,33 +12,42 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ matrix.node }}
           cache: "yarn"
       - run: yarn install
       - run: yarn run lint
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ matrix.node }}
           cache: "yarn"
       - run: yarn install
       - run: yarn run test
 
   build_docs:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20, 22]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ matrix.node }}
           cache: "yarn"
       - run: yarn install
       - run: npm i


### PR DESCRIPTION
This pull request updates the Node.js versions in the GitHub Actions workflows. The lint, test, and build_docs jobs now use a matrix strategy to run on multiple Node.js versions (18, 20, 22). This ensures that the workflows are tested against different Node.js versions for compatibility.